### PR TITLE
Delete deps if build is skipped

### DIFF
--- a/bin/postinstall.js
+++ b/bin/postinstall.js
@@ -1,13 +1,26 @@
-var path = require('path');
-var fs   = require('fs');
-var glob = require('glob');
-var _    = require('underscore');
+const path = require('path');
+const fs   = require('fs');
+const glob = require('glob');
+const _    = require('underscore');
+const rimraf = require('rimraf');
 
-deleteBuildFiles(function(err) {
+deleteDepSources(function(err) {
+  deleteBuildFiles(function(err) {
+  });
 });
 
+function deleteDepSources(cb) {
+  const buildPath = path.resolve(__dirname, '..', 'build');
+  const keepDeps = fs.existsSync(buildPath);
+  if(keepDeps){
+      return cb(null);
+  }
+  const depsPath = path.resolve(__dirname, '..', 'deps');
+  rimraf(depsPath, cb);
+}
+
 function deleteBuildFiles(cb) {
-  var pattern = path.resolve(__dirname, '..', 'build', '**', '*');
+  const pattern = path.resolve(__dirname, '..', 'build', '**', '*');
   glob(pattern, {nodir:true}, function(err, files) {
     if (err) {
       return cb(err);
@@ -17,8 +30,8 @@ function deleteBuildFiles(cb) {
       return /cld\.(node|pdb)$/.test(val)
     });
 
-    for (var i = 0; i < files.length; i++) {
-      var file = files[i];
+    for (let i = 0; i < files.length; i++) {
+      const file = files[i];
       fs.unlinkSync(file);
     }
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "build:native": "prebuildify --napi --strip",
     "build:alpine": "prebuildify-cross -i alpine --napi --strip",
     "test": "node test/runner.js",
-    "install": "node-gyp-build"
+    "install": "node-gyp-build",
+    "postinstall": "node bin/postinstall.js"
   },
   "author": {
     "name": "Blagovest Dachev",
@@ -49,6 +50,7 @@
   "devDependencies": {
     "node-gyp": "^7.1.2",
     "prebuildify": "^4.1.2",
-    "prebuildify-cross": "^4.0.1"
+    "prebuildify-cross": "^4.0.1",
+    "rimraf": "^3.0.2"
   }
 }


### PR DESCRIPTION
When there is no need to build from source, then delete `deps` folder during post-install