### PR TITLE
Removed obsolete declaration

### DIFF
--- a/src/cld.cc
+++ b/src/cld.cc
@@ -6,7 +6,6 @@
 #include "constants.h"
 
 using std::terminate_handler;
-using std::unexpected_handler;
 
 #define NAPI_VERSION 4
 #include <napi.h>


### PR DESCRIPTION
## The same commit in the parent fork
- https://github.com/dachev/node-cld/commit/e0042ae65fb18f08b75b6fd19f6388561423e840

## Reason
- https://github.com/marktext/marktext/issues/2435#issuecomment-961379972